### PR TITLE
fix bignum dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/dmarcelino/b62#readme",
   "dependencies": {
-    "bignum": "^0.10.0"
+    "bignum": "^0.11.0"
   },
   "devDependencies": {
     "mocha": "^2.2.5"


### PR DESCRIPTION
"npm install b62" failed because it depends on old bignum.
